### PR TITLE
Export to svg

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/bpmn-io/bpmn-to-image.svg?branch=master)](https://travis-ci.org/bpmn-io/bpmn-to-image)
 
-Convert [BPMN 2.0 diagrams](https://www.omg.org/spec/BPMN/2.0) to PDF documents or PNG files.
+Convert [BPMN 2.0 diagrams](https://www.omg.org/spec/BPMN/2.0) to PDF documents, SVG or PNG files.
 
 
 ## Usage
@@ -36,8 +36,8 @@ $ bpmn-to-image --help
     # export to diagram.png
     $ bpmn-to-image diagram.bpmn:diagram.png
 
-    # export diagram.png and /tmp/diagram.pdf
-    $ bpmn-to-image diagram.bpmn:diagram.png,/tmp/diagram.pdf
+    # export diagram.png, diagram.svg and /tmp/diagram.pdf
+    $ bpmn-to-image diagram.bpmn:diagram.png,diagram.svg,/tmp/diagram.pdf
 
     # export with minimum size of 500x300 pixels
     $ bpmn-to-image --min-dimensions=500x300 diagram.bpmn:png
@@ -59,6 +59,7 @@ await convertAll([
     outputs: [
       'diagram.pdf',
       'diagram.png'
+      'diagram.svg'
     ]
   }
 ]);

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const puppeteer = require('puppeteer');
+const fs = require('fs');
 
 const {
   basename,
@@ -69,7 +70,6 @@ async function printDiagram(page, options) {
         height: desiredViewport.diagramHeight
       });
     } else
-
     if (output.endsWith('.png')) {
       await page.screenshot({
         path: output,
@@ -79,6 +79,17 @@ async function printDiagram(page, options) {
           width: desiredViewport.width,
           height: desiredViewport.diagramHeight
         }
+      });
+    } else
+    if (output.endsWith('.svg')) {
+      bpmnViewer = new BpmnJS({
+        container: '#canvas'
+      });
+
+      bpmnJS.importXML(someXML);
+
+      bpmnJS.saveSVG(function(err, svg) {
+        fs.writeFileSync(output, svg);
       });
     } else {
       console.error(`Unknown output file format: ${output}`);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bpmn-to-image",
   "version": "0.3.2",
-  "description": "Convert a BPMN 2.0 diagrams to PDF or PNG images",
+  "description": "Convert a BPMN 2.0 diagrams to PDF, SVG or PNG images",
   "main": "index.js",
   "bin": {
     "bpmn-to-image": "./cli.js"
@@ -22,7 +22,8 @@
     "converter",
     "cli",
     "pdf",
-    "png"
+    "png",
+    "svg"
   ],
   "author": "Nico Rehwaldt <https://github.com/nikku>",
   "license": "MIT",

--- a/test/index-spec.js
+++ b/test/index-spec.js
@@ -18,6 +18,7 @@ const input = path.join(__dirname, 'diagram.bpmn');
 
 const outputPNG = path.join(__dirname, 'diagram.png');
 const outputPDF = path.join(__dirname, 'diagram.pdf');
+const outputSVG = path.join(__dirname, 'diagram.svg');
 
 
 describe('index', function() {
@@ -44,13 +45,14 @@ describe('index', function() {
       await convertAll([
         {
           input,
-          outputs: [ outputPNG, outputPDF ]
+          outputs: [ outputPNG, outputPDF, outputSVG ]
         }
       ]);
 
       // then
       expectExists(outputPNG, true);
       expectExists(outputPDF, true);
+      expectExists(outputSVG, true);
     });
 
   });


### PR DESCRIPTION
Save svg rendered image directly.

This is a tentative PR as it is saving the bpmn xml right now.

I think it needs to find the rendered object in skeleton.html. Something like:

```
try {
  const url = await page.evaluate(() => document.querySelect('#svg').src)
  const content = await getImageContent(page, url);
  const contentBuffer = Buffer.from(content, 'base64');
  fs.writeFileSync('logo-extracted.svg', contentBuffer, 'base64');
} catch (e) {
  console.log(e);
}
```

