### PR TITLE
fix width when running inside docker

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,8 +50,8 @@ async function printDiagram(page, options) {
   });;
 
   page.setViewport({
-    width: desiredViewport.width,
-    height: desiredViewport.height
+    width: Math.round(desiredViewport.width),
+    height: Math.round(desiredViewport.height)
   });
 
   await page.evaluate(() => {


### PR DESCRIPTION
Yesterday I opened an issue: https://github.com/bpmn-io/bpmn-to-image/issues/10

It's about an error that ocurrs just inside Docker Containers and happens with specific `.bpmn`. Depending on the `bpmn` file the width returning from `desiredViewport` is not integer, it's a float, causing the puppeteer to raise an exception.

I dont really know why it happens but the solution was to round the returned value from `desiredViewport` 