### PR TITLE
[BREAKING] Rework CLI path format

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -18,7 +18,7 @@ const {
 const cli = meow(`
   Usage
 
-    $ bpmn-to-image <diagramFile>${pathDelimiter}<outputConfig> ...
+    $ bpmn-to-image --destination=<outputConfig> <diagramFile>
 
   Options
 
@@ -37,13 +37,13 @@ const cli = meow(`
   Examples
 
     # export to diagram.png
-    $ bpmn-to-image diagram.bpmn${pathDelimiter}diagram.png
+    $ bpmn-to-image --destination=diagram.png diagram.bpmn
 
     # export diagram.png and /tmp/diagram.pdf
-    $ bpmn-to-image diagram.bpmn${pathDelimiter}diagram.png,/tmp/diagram.pdf
+    $ bpmn-to-image --destination=diagram.png,/tmp/diagram.pdf diagram.bpmn
 
     # export with minimum size of 500x300 pixels
-    $ bpmn-to-image --min-dimensions=500x300 diagram.bpmn${pathDelimiter}png
+    $ bpmn-to-image --min-dimensions=500x300 --destination=diagram.png diagram.bpmn
 `, {
   flags: {
     minDimensions: {
@@ -58,6 +58,9 @@ const cli = meow(`
     },
     scale: {
       default: 1
+    },
+    destination: {
+      type: 'string'
     }
   }
 });
@@ -65,19 +68,9 @@ const cli = meow(`
 if (cli.input.length == 0)
   cli.showHelp(1);
 
-const conversions = cli.input.map(function(conversion) {
-
-  const hasDelimiter = conversion.includes(pathDelimiter);
-  if (!hasDelimiter) {
-     console.error(error(`  Error: no <diagramFile>${pathDelimiter}<outputConfig> param provided`));
-     cli.showHelp(1);
-  }
-
-  const [
-    input,
-    output
-  ] = conversion.split(pathDelimiter);
-
+const conversion = (function(conversion) {
+  const input = conversion;
+  const output = cli.flags.destination;
   const outputs = output.split(',').reduce(function(outputs, file, idx) {
 
     // just extension
@@ -96,7 +89,7 @@ const conversions = cli.input.map(function(conversion) {
     input,
     outputs
   }
-});
+})(cli.input[0])
 
 const footer = cli.flags.footer;
 
@@ -107,7 +100,8 @@ const scale = cli.flags.scale !== undefined ? cli.flags.scale : 1;
 const [ width, height ] = cli.flags.minDimensions.split('x').map(function(d) {
   return parseInt(d, 10);
 });
-convertAll(conversions, {
+
+convertAll([conversion], {
   minDimensions: { width, height },
   title,
   footer,

--- a/cli.js
+++ b/cli.js
@@ -65,7 +65,7 @@ const cli = meow(`
   }
 });
 
-if (cli.input.length == 0)
+if (cli.input.length == 0 || !cli.flags.destination)
   cli.showHelp(1);
 
 const conversion = (function(conversion) {

--- a/test/cli-spec.js
+++ b/test/cli-spec.js
@@ -4,7 +4,6 @@ const del = require('del');
 
 const {
   join: joinPath,
-  delimiter: pathDelimiter
 } = require('path');
 
 const {

--- a/test/cli-spec.js
+++ b/test/cli-spec.js
@@ -29,6 +29,25 @@ describe('cli', function() {
 
   });
 
+  describe('missing destination', function () {
+    it('prints instruction', async function () {
+
+      // when
+      runExport([
+        'diagram.bpmn'
+      ]).then(
+        function (result) {},
+        function (error) {
+          expect(error).to.exist;
+        }
+      )
+
+      // then
+      expectExists('diagram.pdf', false);
+      expectExists('diagram.png', false);
+      expectExists('diagram.svg', false);
+    });
+  });
 
   describe('should export images', function() {
 

--- a/test/cli-spec.js
+++ b/test/cli-spec.js
@@ -36,7 +36,7 @@ describe('cli', function() {
 
       // when
       await runExport([
-        `diagram.bpmn${pathDelimiter}pdf`
+        '--destination=pdf', 'diagram.bpmn'
       ]);
 
       // then
@@ -49,7 +49,8 @@ describe('cli', function() {
 
       // when
       await runExport([
-        `${ joinPath(__dirname, 'complex.bpmn') }${pathDelimiter}complex_export.pdf,complex_img.png`
+        '--destination=complex_export.pdf,complex_img.png',
+        `${ joinPath(__dirname, 'complex.bpmn') }`
       ]);
 
       // then
@@ -62,26 +63,13 @@ describe('cli', function() {
 
       // when
       await runExport([
-        `diagram.bpmn${pathDelimiter}${ joinPath(__dirname, 'diagram_export.png') },pdf`
+        `--destination=${ joinPath(__dirname, 'diagram_export.png') },pdf`,
+        'diagram.bpmn'
       ]);
 
       // then
       expectExists('diagram_export.png', true);
       expectExists('diagram_export.pdf', true);
-    });
-
-
-    it('multiple files', async function() {
-
-      // when
-      await runExport([
-        `diagram.bpmn${pathDelimiter}png`,
-        `complex.bpmn${pathDelimiter}png`
-      ]);
-
-      // then
-      expectExists('diagram.png', true);
-      expectExists('complex.png', true);
     });
 
 
@@ -91,12 +79,10 @@ describe('cli', function() {
 
         // when
         await runExport([
-          `small.bpmn${pathDelimiter}small_default.png`,
-          `vertical.bpmn${pathDelimiter}png`
+          '--destination=png', 'vertical.bpmn'
         ]);
 
         // then
-        expectExists('small_default.png', true);
         expectExists('vertical.png', true);
       });
 
@@ -105,7 +91,7 @@ describe('cli', function() {
 
         // when
         await runExport([
-          `small.bpmn${pathDelimiter}small_custom_size.png`
+          '--destination=small_custom_size.png', 'small.bpmn'
         ], {
           minDimensions: {
             width: 500,
@@ -126,7 +112,7 @@ describe('cli', function() {
 
         // when
         await runExport([
-          `title.bpmn${pathDelimiter}title_default.png`
+          '--destination=title_default.png', 'title.bpmn'
         ]);
 
         // then
@@ -138,7 +124,7 @@ describe('cli', function() {
 
         // when
         await runExport([
-          `title.bpmn${pathDelimiter}custom_title.png`
+          '--destination=custom_title.png', 'title.bpmn'
         ], {
           title: 'FOO BAR'
         });
@@ -152,7 +138,7 @@ describe('cli', function() {
 
         // when
         await runExport([
-          `title.bpmn${pathDelimiter}no_title.png`
+          '--destination=no_title.png', 'title.bpmn'
         ], {
           title: false
         });
@@ -170,7 +156,7 @@ describe('cli', function() {
 
         // when
         await runExport([
-          `title.bpmn${pathDelimiter}no_footer.png`
+          '--destination=no_footer.png', 'title.bpmn'
         ], {
           noFooter: true
         });
@@ -188,7 +174,7 @@ describe('cli', function() {
 
         // when
         await runExport([
-          `title.bpmn${pathDelimiter}scaled.png`
+          '--destination=scaled.png', 'title.bpmn'
         ], {
           scale: 0.5
         });


### PR DESCRIPTION
Relates to #15

This is a first step towards introduction of stdin and stdout as
input/output streams. 

Breaking changes:

The format is now `bpmn-to-image --destination=<outputConfig> <diagramFile>`.
As a consequence, you can only convert one _source_ per run. 

This enables us to move forward to using stdin as input source