### PR TITLE
feat: Support for subdiagram export

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ $ bpmn-to-image --help
 
     --scale                        Scale factor for images (1)
 
+    --subdiagrams                  Export collapsed sub-process diagrams too
+
+  When enabled, PDF outputs include one page per collapsed sub-process, and PNG/SVG outputs produce additional files suffixed with `-sub1`, `-sub2`, ...
+
   Examples
 
     # export to diagram.png

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ $ bpmn-to-image --help
 
     --subdiagrams                  Export collapsed sub-process diagrams too
 
-  When enabled, PDF outputs include one page per collapsed sub-process, and PNG/SVG outputs produce additional files suffixed with `-sub1`, `-sub2`, ...
+  When enabled, PDF outputs include one page per collapsed sub-process, and PNG/SVG outputs produce additional files suffixed with the cleaned element ID of the collapsed sub-process (for example, `-1utzm6g`, `-1k00b0l`).
 
   Examples
 

--- a/cli.js
+++ b/cli.js
@@ -33,6 +33,8 @@ const cli = meow(`
 
     --scale                        Scale factor for images (1)
 
+    --subdiagrams                  Export collapsed sub-process diagrams too
+
   Examples
 
     # export to diagram.png
@@ -58,6 +60,10 @@ const cli = meow(`
     },
     scale: {
       default: 1
+    },
+    subdiagrams: {
+      type: 'boolean',
+      default: false
     }
   }
 });
@@ -105,6 +111,8 @@ const title = cli.flags.title === false ? false : cli.flags.title;
 
 const scale = cli.flags.scale !== undefined ? parseFloat(cli.flags.scale) : 1;
 
+const subDiagrams = !!cli.flags.subdiagrams;
+
 if (isNaN(scale)) {
   console.error('<scale> is not a number');
 
@@ -119,7 +127,8 @@ convertAll(conversions, {
   minDimensions: { width, height },
   title,
   footer,
-  deviceScaleFactor: scale
+  deviceScaleFactor: scale,
+  subDiagrams
 }).catch(function(e) {
   console.error('failed to export diagram(s)');
   console.error(e);

--- a/index.js
+++ b/index.js
@@ -44,29 +44,15 @@ async function printDiagram(page, options) {
 
   const diagrams = await page.evaluate(async function(diagramXML, options) {
 
-    const {
-      viewerScript
-    } = options;
+    const { viewerScript } = options;
 
     await loadScript(viewerScript);
 
-    return importDiagram(diagramXML);
-  }, diagramXML, {
-    viewerScript
-  });
+    return computeExportPlan(diagramXML);
+  }, diagramXML, { viewerScript });
 
   if (!diagrams.length) {
     throw new Error('no BPMN diagrams found in input');
-  }
-
-  const diagramsToExport = [ diagrams[0] ];
-
-  if (subDiagrams) {
-    diagramsToExport.push(
-      ...diagrams.filter(function(diagram) {
-        return diagram.isSubProcess && diagram.isCollapsed;
-      })
-    );
   }
 
   const pdfOutputs = outputs.filter(o => o.endsWith('.pdf'));
@@ -74,17 +60,17 @@ async function printDiagram(page, options) {
 
   const pdfBuffers = new Map(pdfOutputs.map(o => [ o, [] ]));
 
-  for (let diagramIndex = 0; diagramIndex < diagramsToExport.length; diagramIndex++) {
+  for (let i = 0; i < diagrams.length; i++) {
 
-    const diagram = diagramsToExport[diagramIndex];
+    const { id: diagramId, name, elementId } = diagrams[i];
 
-    const diagramSpecificTitle = diagramIndex === 0 || !diagramTitle
+    const diagramSpecificTitle = (i === 0 || !diagramTitle)
       ? diagramTitle
-      : `${diagramTitle} – ${diagram.name || diagram.elementId}`;
+      : `${diagramTitle} – ${name || diagramId}`;
 
     const desiredViewport = await page.evaluate(async function(diagramId, openOptions) {
       return openAndCompute(diagramId, openOptions);
-    }, diagram.id, {
+    }, diagramId, {
       minDimensions,
       title: diagramSpecificTitle,
       footer
@@ -100,7 +86,13 @@ async function printDiagram(page, options) {
 
     for (const output of otherOutputs) {
 
-      const targetOutput = diagramIndex === 0 ? output : addSuffix(output, `-sub${diagramIndex}`);
+      const cleanId = cleanElementId(elementId);
+
+      const suffix = (cleanId && i > 0)
+        ? `-${cleanId}`
+        : '';
+
+      const targetOutput = suffix ? addSuffix(output, suffix) : output;
 
       console.log(`writing ${targetOutput}`);
 
@@ -210,6 +202,25 @@ export async function convert(input, output) {
       outputs: [ output ]
     }
   ]);
+}
+
+/**
+ * Clean BPMN element ids for filename use.
+ * Strips common prefixes such as "Activity_" while keeping the remainder intact.
+ *
+ * @param {string} elementId
+ * @return {string}
+ */
+function cleanElementId(elementId) {
+  if (!elementId) {
+    return '';
+  }
+
+  if (elementId.startsWith('Activity_')) {
+    return elementId.substring('Activity_'.length);
+  }
+
+  return elementId;
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -44,12 +44,12 @@ async function printDiagram(page, options) {
 
   const diagrams = await page.evaluate(async function(diagramXML, options) {
 
-    const { viewerScript } = options;
+    const { viewerScript, subDiagrams } = options;
 
     await loadScript(viewerScript);
 
-    return computeExportPlan(diagramXML);
-  }, diagramXML, { viewerScript });
+    return computeExportPlan(diagramXML, { subDiagrams });
+  }, diagramXML, { viewerScript, subDiagrams });
 
   if (!diagrams.length) {
     throw new Error('no BPMN diagrams found in input');

--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ async function printDiagram(page, options) {
       footer
     });
 
-    page.setViewport({
+    await page.setViewport({
       width: Math.round(desiredViewport.width),
       height: Math.round(desiredViewport.height),
       deviceScaleFactor

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 import puppeteer from 'puppeteer';
+import { PDFDocument } from 'pdf-lib';
 
 import {
   basename,
@@ -27,75 +28,125 @@ async function printDiagram(page, options) {
     minDimensions,
     footer,
     title = true,
-    deviceScaleFactor
+    deviceScaleFactor,
+    subDiagrams = false
   } = options;
 
   const diagramXML = readFileSync(input, 'utf8');
 
   const diagramTitle = title === false ? false : (
-    title.length ? title : basename(input)
+    (typeof title === 'string' && title.length) ? title : basename(input)
   );
 
   await page.goto(new URL('./skeleton.html', import.meta.url));
 
   const viewerScript = import.meta.resolve('bpmn-js/dist/bpmn-viewer.production.min.js');
 
-  const desiredViewport = await page.evaluate(async function(diagramXML, options) {
+  const diagrams = await page.evaluate(async function(diagramXML, options) {
 
     const {
-      viewerScript,
-      ...openOptions
+      viewerScript
     } = options;
 
     await loadScript(viewerScript);
 
-    // returns desired viewport
-    return openDiagram(diagramXML, openOptions);
+    return importDiagram(diagramXML);
   }, diagramXML, {
-    minDimensions,
-    title: diagramTitle,
-    viewerScript,
-    footer
-  });;
-
-  page.setViewport({
-    width: Math.round(desiredViewport.width),
-    height: Math.round(desiredViewport.height),
-    deviceScaleFactor
+    viewerScript
   });
 
-  await page.evaluate(() => resize());
+  if (!diagrams.length) {
+    throw new Error('no BPMN diagrams found in input');
+  }
 
-  for (const output of outputs) {
+  const diagramsToExport = [ diagrams[0] ];
+
+  if (subDiagrams) {
+    diagramsToExport.push(
+      ...diagrams.filter(function(diagram) {
+        return diagram.isSubProcess && diagram.isCollapsed;
+      })
+    );
+  }
+
+  const pdfOutputs = outputs.filter(o => o.endsWith('.pdf'));
+  const otherOutputs = outputs.filter(o => !o.endsWith('.pdf'));
+
+  const pdfBuffers = new Map(pdfOutputs.map(o => [ o, [] ]));
+
+  for (let diagramIndex = 0; diagramIndex < diagramsToExport.length; diagramIndex++) {
+
+    const diagram = diagramsToExport[diagramIndex];
+
+    const diagramSpecificTitle = diagramIndex === 0 || !diagramTitle
+      ? diagramTitle
+      : `${diagramTitle} – ${diagram.name || diagram.elementId}`;
+
+    const desiredViewport = await page.evaluate(async function(diagramId, openOptions) {
+      return openAndCompute(diagramId, openOptions);
+    }, diagram.id, {
+      minDimensions,
+      title: diagramSpecificTitle,
+      footer
+    });
+
+    page.setViewport({
+      width: Math.round(desiredViewport.width),
+      height: Math.round(desiredViewport.height),
+      deviceScaleFactor
+    });
+
+    await page.evaluate(() => resize());
+
+    for (const output of otherOutputs) {
+
+      const targetOutput = diagramIndex === 0 ? output : addSuffix(output, `-sub${diagramIndex}`);
+
+      console.log(`writing ${targetOutput}`);
+
+      if (output.endsWith('.png')) {
+        await page.screenshot({
+          path: targetOutput,
+          clip: {
+            x: 0,
+            y: 0,
+            width: desiredViewport.width,
+            height: desiredViewport.diagramHeight
+          }
+        });
+      } else
+      if (output.endsWith('.svg')) {
+
+        const svg = await page.evaluate(() => toSVG());
+
+        writeFileSync(targetOutput, svg, 'utf8');
+      } else {
+        console.error(`Unknown output file format: ${output}`);
+      }
+    }
+
+    for (const output of pdfOutputs) {
+      const buffer = await page.pdf({
+        width: desiredViewport.width,
+        height: desiredViewport.diagramHeight,
+        printBackground: true
+      });
+
+      pdfBuffers.get(output).push(buffer);
+    }
+  }
+
+  for (const [ output, buffers ] of pdfBuffers.entries()) {
+
+    if (!buffers.length) {
+      continue;
+    }
 
     console.log(`writing ${output}`);
 
-    if (output.endsWith('.pdf')) {
-      await page.pdf({
-        path: output,
-        width: desiredViewport.width,
-        height: desiredViewport.diagramHeight
-      });
-    } else
-    if (output.endsWith('.png')) {
-      await page.screenshot({
-        path: output,
-        clip: {
-          x: 0,
-          y: 0,
-          width: desiredViewport.width,
-          height: desiredViewport.diagramHeight
-        }
-      });
-    } else
-    if (output.endsWith('.svg')) {
+    const merged = await mergePdf(buffers);
 
-      const svg = await page.evaluate(() => toSVG());
-
-      writeFileSync(output, svg, 'utf8');
-    } else {
-      console.error(`Unknown output file format: ${output}`);
-    }
+    writeFileSync(output, merged);
   }
 
 }
@@ -124,7 +175,8 @@ export async function convertAll(conversions, options={}) {
     minDimensions,
     footer,
     title,
-    deviceScaleFactor
+    deviceScaleFactor,
+    subDiagrams
   } = options;
 
   await withPage(async function(page) {
@@ -142,7 +194,8 @@ export async function convertAll(conversions, options={}) {
         minDimensions,
         title,
         footer,
-        deviceScaleFactor
+        deviceScaleFactor,
+        subDiagrams
       });
     }
 
@@ -157,4 +210,43 @@ export async function convert(input, output) {
       outputs: [ output ]
     }
   ]);
+}
+
+/**
+ * Add a suffix before the file extension.
+ *
+ * @param {string} filePath
+ * @param {string} suffix
+ * @return {string}
+ */
+function addSuffix(filePath, suffix) {
+
+  const lastDot = filePath.lastIndexOf('.');
+
+  if (lastDot === -1) {
+    return `${filePath}${suffix}`;
+  }
+
+  return `${filePath.substring(0, lastDot)}${suffix}${filePath.substring(lastDot)}`;
+}
+
+/**
+ * Merge multiple PDF buffers into a single document.
+ *
+ * @param {Array<Uint8Array>} buffers
+ * @return {Promise<Uint8Array>}
+ */
+async function mergePdf(buffers) {
+
+  const mergedPdf = await PDFDocument.create();
+
+  for (const buffer of buffers) {
+    const doc = await PDFDocument.load(buffer);
+
+    const copiedPages = await mergedPdf.copyPages(doc, doc.getPageIndices());
+
+    copiedPages.forEach(page => mergedPdf.addPage(page));
+  }
+
+  return mergedPdf.save();
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "bpmn-js": "^18.9.1",
         "chalk": "^5.6.2",
         "meow": "^14.0.0",
+        "pdf-lib": "^1.17.1",
         "puppeteer": "^24.34.0"
       },
       "bin": {
@@ -240,6 +241,24 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@pdf-lib/standard-fonts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz",
+      "integrity": "sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.6"
+      }
+    },
+    "node_modules/@pdf-lib/upng": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/upng/-/upng-1.0.1.tgz",
+      "integrity": "sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.10"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -2140,6 +2159,12 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -2205,6 +2230,24 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/pdf-lib": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.17.1.tgz",
+      "integrity": "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@pdf-lib/standard-fonts": "^1.0.0",
+        "@pdf-lib/upng": "^1.0.1",
+        "pako": "^1.0.11",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/pdf-lib/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
     "node_modules/pend": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "bpmn-js": "^18.9.1",
     "chalk": "^5.6.2",
     "meow": "^14.0.0",
+    "pdf-lib": "^1.17.1",
     "puppeteer": "^24.34.0"
   },
   "devDependencies": {

--- a/skeleton.html
+++ b/skeleton.html
@@ -75,17 +75,109 @@
       }
 
       /**
-       * Open diagram in our viewer instance.
+       * Update footer title visibility and text.
        *
-       * @param {String} bpmnXML diagram to display
+       * @param {string|boolean} title
+       */
+      function setTitle(title) {
+        const titleNode = document.querySelector('#title');
+
+        if (title) {
+          titleNode.textContent = title;
+        }
+
+        titleNode.style.display = title ? 'block' : 'none';
+      }
+
+      /**
+       * Return all BPMN diagrams known to the current viewer.
+       *
+       * @return {Array<{ id: string, name: string, elementId: string, isCollapsed: boolean, isSubProcess: boolean, isDefault: boolean }>}
+       */
+      function listDiagrams() {
+        if (!bpmnViewer) {
+          return [];
+        }
+
+        const definitions = bpmnViewer.getDefinitions();
+
+        const diagrams = definitions && definitions.diagrams || [];
+
+        return diagrams.map(function(diagram, idx) {
+
+          const bpmnElement = diagram.plane && diagram.plane.bpmnElement;
+
+          const elementRegistry = bpmnViewer.get('elementRegistry');
+
+          const diagramElement = elementRegistry && bpmnElement && elementRegistry.get(bpmnElement.id);
+
+          const di = diagramElement && diagramElement.di;
+
+          return {
+            id: diagram.id,
+            name: bpmnElement && bpmnElement.name,
+            elementId: bpmnElement && bpmnElement.id,
+            isCollapsed: di && di.isExpanded === false,
+            isSubProcess: bpmnElement && bpmnElement.$type === 'bpmn:SubProcess',
+            isDefault: idx === 0
+          };
+        });
+      }
+
+      /**
+       * Import XML into the viewer and return diagram metadata.
+       *
+       * @param {string} bpmnXML
+       * @return {Promise<Array>}
+       */
+      async function importDiagram(bpmnXML) {
+
+        const bpmnViewer = getViewer();
+
+        await bpmnViewer.importXML(bpmnXML);
+
+        return listDiagrams();
+      }
+
+      /**
+       * Open a diagram by its BPMNDiagram id.
+       *
+       * @param {string} diagramId
+       * @return {Promise<void>}
+       */
+      async function openDiagramById(diagramId) {
+
+        const bpmnViewer = getViewer();
+
+        const diagrams = listDiagrams();
+
+        const diagram = diagrams.map(d => d.id).includes(diagramId)
+          ? bpmnViewer.getDefinitions().diagrams.find(d => d.id === diagramId)
+          : bpmnViewer.getDefinitions().diagrams[0];
+
+        if (!diagram) {
+          throw new Error('no diagram found');
+        }
+
+        if (typeof bpmnViewer.open === 'function') {
+          await bpmnViewer.open(diagram);
+        } else {
+          const canvas = bpmnViewer.get('canvas');
+
+          canvas.setRootElement(diagram.plane.bpmnElement, diagram.plane);
+        }
+      }
+
+      /**
+       * Get viewport for the currently opened diagram.
+       *
        * @param {Object} [options]
        * @param {Dimensions} [options.minDimensions]
        *
        * @return {Promise<Bounds, Error>}
        */
-      async function openDiagram(bpmnXML, options) {
+      async function computeViewport(options) {
 
-        // viewer instance, lazily initialized
         const bpmnViewer = getViewer();
 
         options = options || {};
@@ -99,18 +191,9 @@
 
         const footer = options.footer;
 
-        await bpmnViewer.importXML(bpmnXML);
+        setTitle(title);
 
         const viewbox = bpmnViewer.get('canvas').viewbox();
-
-        // uses provided title
-        const titleNode = document.querySelector('#title');
-
-        if (title) {
-          titleNode.textContent = title;
-        }
-
-        titleNode.style.display = title ? 'block' : 'none';
 
         const width = Math.max(viewbox.inner.width, minDimensions.width);
         const diagramHeight = Math.max(
@@ -123,6 +206,40 @@
           height: diagramHeight + (footer ? 0 : 90),
           diagramHeight
         };
+      }
+
+      /**
+       * Open a diagram by id and compute its viewport bounds.
+       *
+       * @param {string} diagramId
+       * @param {Object} [options]
+       * @return {Promise<Bounds>}
+       */
+      async function openAndCompute(diagramId, options) {
+
+        await openDiagramById(diagramId);
+
+        await resize();
+
+        return computeViewport(options);
+      }
+
+      /**
+       * Open diagram in our viewer instance.
+       *
+       * @param {String} bpmnXML diagram to display
+       * @param {Object} [options]
+       * @param {Dimensions} [options.minDimensions]
+       *
+       * @return {Promise<Bounds, Error>}
+       */
+      async function openDiagram(bpmnXML, options) {
+
+        const diagrams = await importDiagram(bpmnXML);
+
+        const targetId = options && options.diagramId || (diagrams[0] && diagrams[0].id);
+
+        return openAndCompute(targetId, options);
       }
 
       /**

--- a/skeleton.html
+++ b/skeleton.html
@@ -111,11 +111,17 @@
 
           const diagramElement = elementRegistry && bpmnElement && elementRegistry.get(bpmnElement.id);
 
+          const di = bpmnElement && bpmnElement.di;
+
+          const isCollapsed = diagramElement
+            ? diagramElement.collapsed === true
+            : di && di.isExpanded === false;
+
           return {
             id: diagram.id,
             name: bpmnElement && bpmnElement.name,
             elementId: bpmnElement && bpmnElement.id,
-            isCollapsed: diagramElement && diagramElement.collapsed === true,
+            isCollapsed,
             isSubProcess: bpmnElement && bpmnElement.$type === 'bpmn:SubProcess'
           };
         });

--- a/skeleton.html
+++ b/skeleton.html
@@ -117,7 +117,7 @@
             id: diagram.id,
             name: bpmnElement && bpmnElement.name,
             elementId: bpmnElement && bpmnElement.id,
-            isCollapsed: di && di.isExpanded === false,
+            isCollapsed: diagramElement && diagramElement.collapsed === true,
             isSubProcess: bpmnElement && bpmnElement.$type === 'bpmn:SubProcess',
             isDefault: idx === 0
           };
@@ -166,6 +166,99 @@
 
           canvas.setRootElement(diagram.plane.bpmnElement, diagram.plane);
         }
+      }
+
+      /**
+       * Collect collapsed subprocess shapes in the current diagram.
+       *
+       * @return {Array<{ id: string, name: string }>}
+       */
+      function getCollapsedSubprocessShapes() {
+        const bpmnViewer = getViewer();
+
+        const elementRegistry = bpmnViewer.get('elementRegistry');
+
+        const collapsed = [];
+
+        elementRegistry.forEach(function(element) {
+          const bo = element.businessObject;
+
+          if (!bo || bo.$type !== 'bpmn:SubProcess') {
+            return;
+          }
+
+          // Check if subprocess is collapsed
+          if (element.collapsed === true) {
+            collapsed.push({
+              id: bo.id,
+              name: bo.name || bo.id
+            });
+          }
+        });
+
+        return collapsed;
+      }
+
+      /**
+       * Build export plan: main diagram plus collapsed subprocess diagrams (alphabetically by name).
+       * Skips already visited elementIds to avoid cycles.
+       *
+       * @param {string} bpmnXML
+       * @return {Promise<Array<{ id: string, name: string, elementId: string }>>}
+       */
+      async function computeExportPlan(bpmnXML) {
+        const diagrams = await importDiagram(bpmnXML);
+
+        const main = diagrams[0];
+
+        const byElementId = {};
+
+        diagrams.forEach(function(diagram) {
+          if (diagram.elementId) {
+            byElementId[diagram.elementId] = diagram;
+          }
+        });
+
+        const plan = [];
+        const visited = new Set();
+
+        // Start with main diagram
+        plan.push({ id: main.id, name: main.name, elementId: main.elementId });
+        visited.add(main.elementId);
+
+        // Open main and collect collapsed subprocesses
+        await openDiagramById(main.id);
+        const collapsed = getCollapsedSubprocessShapes();
+
+        // Add collapsed subprocesses, sorted by name
+        const subdiagramsToAdd = [];
+
+        for (let i = 0; i < collapsed.length; i++) {
+          const child = collapsed[i];
+
+          // Skip if already visited (cycle detection)
+          if (visited.has(child.id)) {
+            continue;
+          }
+
+          const childDiagram = byElementId[child.id];
+
+          if (!childDiagram) {
+            continue;
+          }
+
+          subdiagramsToAdd.push({ id: childDiagram.id, name: child.name, elementId: child.id });
+          visited.add(child.id);
+        }
+
+        // Sort by name for alphabetical ordering in PDF
+        subdiagramsToAdd.sort(function(a, b) {
+          return (a.name || '').localeCompare(b.name || '');
+        });
+
+        plan.push(...subdiagramsToAdd);
+
+        return plan;
       }
 
       /**

--- a/skeleton.html
+++ b/skeleton.html
@@ -92,7 +92,7 @@
       /**
        * Return all BPMN diagrams known to the current viewer.
        *
-       * @return {Array<{ id: string, name: string, elementId: string, isCollapsed: boolean, isSubProcess: boolean, isDefault: boolean }>}
+       * @return {Array<{ id: string, name: string, elementId: string, isCollapsed: boolean, isSubProcess: boolean }>}
        */
       function listDiagrams() {
         if (!bpmnViewer) {
@@ -111,15 +111,12 @@
 
           const diagramElement = elementRegistry && bpmnElement && elementRegistry.get(bpmnElement.id);
 
-          const di = diagramElement && diagramElement.di;
-
           return {
             id: diagram.id,
             name: bpmnElement && bpmnElement.name,
             elementId: bpmnElement && bpmnElement.id,
             isCollapsed: diagramElement && diagramElement.collapsed === true,
-            isSubProcess: bpmnElement && bpmnElement.$type === 'bpmn:SubProcess',
-            isDefault: idx === 0
+            isSubProcess: bpmnElement && bpmnElement.$type === 'bpmn:SubProcess'
           };
         });
       }
@@ -130,7 +127,7 @@
        * @param {string} bpmnXML
        * @return {Promise<Array>}
        */
-      async function importDiagram(bpmnXML) {
+      async function importDiagrams(bpmnXML) {
 
         const bpmnViewer = getViewer();
 
@@ -169,94 +166,50 @@
       }
 
       /**
-       * Collect collapsed subprocess shapes in the current diagram.
-       *
-       * @return {Array<{ id: string, name: string }>}
-       */
-      function getCollapsedSubprocessShapes() {
-        const bpmnViewer = getViewer();
-
-        const elementRegistry = bpmnViewer.get('elementRegistry');
-
-        const collapsed = [];
-
-        elementRegistry.forEach(function(element) {
-          const bo = element.businessObject;
-
-          if (!bo || bo.$type !== 'bpmn:SubProcess') {
-            return;
-          }
-
-          // Check if subprocess is collapsed
-          if (element.collapsed === true) {
-            collapsed.push({
-              id: bo.id,
-              name: bo.name || bo.id
-            });
-          }
-        });
-
-        return collapsed;
-      }
-
-      /**
-       * Build export plan: main diagram plus collapsed subprocess diagrams (alphabetically by name).
-       * Skips already visited elementIds to avoid cycles.
+       * Compute the export plan for all diagrams.
+       * When subDiagrams is true, includes collapsed subprocesses and their nested subprocesses.
+       * When subDiagrams is false, only exports the main diagram.
        *
        * @param {string} bpmnXML
-       * @return {Promise<Array<{ id: string, name: string, elementId: string }>>}
+       * @param {Object} [options]
+       * @param {boolean} [options.subDiagrams=false]
+       * @return {Promise<Array>}
        */
-      async function computeExportPlan(bpmnXML) {
-        const diagrams = await importDiagram(bpmnXML);
+      async function computeExportPlan(bpmnXML, options) {
+        options = options || {};
+        const { subDiagrams = false } = options;
 
-        const main = diagrams[0];
+        const diagrams = await importDiagrams(bpmnXML);
 
-        const byElementId = {};
-
-        diagrams.forEach(function(diagram) {
-          if (diagram.elementId) {
-            byElementId[diagram.elementId] = diagram;
-          }
-        });
+        // Find the main diagram
+        const main = diagrams.find(function(d) {
+          return !d.isSubProcess;
+        }) || diagrams[0];
 
         const plan = [];
-        const visited = new Set();
 
         // Start with main diagram
         plan.push({ id: main.id, name: main.name, elementId: main.elementId });
-        visited.add(main.elementId);
 
-        // Open main and collect collapsed subprocesses
-        await openDiagramById(main.id);
-        const collapsed = getCollapsedSubprocessShapes();
-
-        // Add collapsed subprocesses, sorted by name
-        const subdiagramsToAdd = [];
-
-        for (let i = 0; i < collapsed.length; i++) {
-          const child = collapsed[i];
-
-          // Skip if already visited (cycle detection)
-          if (visited.has(child.id)) {
-            continue;
-          }
-
-          const childDiagram = byElementId[child.id];
-
-          if (!childDiagram) {
-            continue;
-          }
-
-          subdiagramsToAdd.push({ id: childDiagram.id, name: child.name, elementId: child.id });
-          visited.add(child.id);
+        // If subDiagrams is false, return only the main diagram
+        if (!subDiagrams) {
+          return plan;
         }
 
+        // Collect all collapsed subprocesses from all diagrams
+        const collapsed = diagrams.filter(function(d) {
+          return d.isCollapsed && d.elementId;
+        });
+
         // Sort by name for alphabetical ordering in PDF
-        subdiagramsToAdd.sort(function(a, b) {
+        collapsed.sort(function(a, b) {
           return (a.name || '').localeCompare(b.name || '');
         });
 
-        plan.push(...subdiagramsToAdd);
+        // Add all collapsed subprocesses to the plan
+        collapsed.forEach(function(d) {
+          plan.push({ id: d.id, name: d.name, elementId: d.elementId });
+        });
 
         return plan;
       }
@@ -315,24 +268,6 @@
         await resize();
 
         return computeViewport(options);
-      }
-
-      /**
-       * Open diagram in our viewer instance.
-       *
-       * @param {String} bpmnXML diagram to display
-       * @param {Object} [options]
-       * @param {Dimensions} [options.minDimensions]
-       *
-       * @return {Promise<Bounds, Error>}
-       */
-      async function openDiagram(bpmnXML, options) {
-
-        const diagrams = await importDiagram(bpmnXML);
-
-        const targetId = options && options.diagramId || (diagrams[0] && diagrams[0].id);
-
-        return openAndCompute(targetId, options);
       }
 
       /**

--- a/test/cli-spec.cjs
+++ b/test/cli-spec.cjs
@@ -1,15 +1,24 @@
 const { expect } = require('chai');
-
 const {
   join: joinPath,
   delimiter: pathDelimiter
 } = require('node:path');
-
 const {
-  accessSync
+  accessSync,
+  readFileSync
 } = require('node:fs');
-
 const { execa } = require('execa');
+const { PDFDocument } = require('pdf-lib');
+
+const input = joinPath(__dirname, 'diagram.bpmn');
+
+const outputPNG = joinPath(__dirname, 'diagram.png');
+const outputPDF = joinPath(__dirname, 'diagram.pdf');
+const outputSVG = joinPath(__dirname, 'diagram.svg');
+
+const subdiagramInput = joinPath(__dirname, 'subdiagrams.bpmn');
+const subdiagramPNG = joinPath(__dirname, 'subdiagrams.png');
+const subdiagramPDF = joinPath(__dirname, 'subdiagrams.pdf');
 
 
 describe('cli', function() {
@@ -198,6 +207,43 @@ describe('cli', function() {
     });
   });
 
+
+  describe('with sub diagrams', function() {
+
+    it('should export collapsed sub processes as separate images', async function() {
+
+      await runExport([
+        `${ subdiagramInput }${pathDelimiter}${ subdiagramPNG }`
+      ], {
+        subDiagrams: true
+      });
+
+      expectExists('subdiagrams.png', true);
+      expectExists('subdiagrams-1utzm6g.png', true);
+      expectExists('subdiagrams-1k00b0l.png', true);
+      expectExists('subdiagrams-173ua2j.png', true);
+      expectExists('subdiagrams-1elvc1o.png', true);
+    });
+
+
+    it('should merge all diagrams into a single PDF', async function() {
+
+      await runExport([
+        `${ subdiagramInput }${pathDelimiter}${ subdiagramPDF }`
+      ], {
+        subDiagrams: true
+      });
+
+      expectExists('subdiagrams.pdf', true);
+
+      const pdfBuffer = readFileSync(subdiagramPDF);
+      const pdfDoc = await PDFDocument.load(pdfBuffer);
+
+      expect(pdfDoc.getPageCount()).to.equal(5);
+    });
+
+  });
+
 });
 
 
@@ -210,7 +256,8 @@ async function runExport(conversions, options = {}) {
     minDimensions,
     title,
     noFooter,
-    scale
+    scale,
+    subDiagrams
   } = options;
 
   if (noFooter) {
@@ -249,6 +296,13 @@ async function runExport(conversions, options = {}) {
         `--title=${title}`
       ];
     }
+  }
+
+  if (subDiagrams) {
+    args = [
+      ...args,
+      '--subdiagrams'
+    ];
   }
 
   await execa('../cli.js', args, {

--- a/test/cli-spec.cjs
+++ b/test/cli-spec.cjs
@@ -1,25 +1,21 @@
 const { expect } = require('chai');
+
 const {
   join: joinPath,
   delimiter: pathDelimiter
 } = require('node:path');
+
 const {
   accessSync,
   readFileSync
 } = require('node:fs');
+
 const { execa } = require('execa');
 const { PDFDocument } = require('pdf-lib');
-
-const input = joinPath(__dirname, 'diagram.bpmn');
-
-const outputPNG = joinPath(__dirname, 'diagram.png');
-const outputPDF = joinPath(__dirname, 'diagram.pdf');
-const outputSVG = joinPath(__dirname, 'diagram.svg');
 
 const subdiagramInput = joinPath(__dirname, 'subdiagrams.bpmn');
 const subdiagramPNG = joinPath(__dirname, 'subdiagrams.png');
 const subdiagramPDF = joinPath(__dirname, 'subdiagrams.pdf');
-
 
 describe('cli', function() {
 
@@ -240,6 +236,39 @@ describe('cli', function() {
       const pdfDoc = await PDFDocument.load(pdfBuffer);
 
       expect(pdfDoc.getPageCount()).to.equal(5);
+    });
+
+  });
+
+
+  describe('ignoring sub diagrams', function() {
+
+    it('should export only main diagram as PNG when subDiagrams flag is not set', async function() {
+
+      await runExport([
+        `${ subdiagramInput }${pathDelimiter}subdiagrams-no-subs.png`
+      ]);
+
+      expectExists('subdiagrams-no-subs.png', true);
+      expectExists('subdiagrams-no-subs-1utzm6g.png', false);
+      expectExists('subdiagrams-no-subs-1k00b0l.png', false);
+      expectExists('subdiagrams-no-subs-173ua2j.png', false);
+      expectExists('subdiagrams-no-subs-1elvc1o.png', false);
+    });
+
+
+    it('should export only main diagram as PDF when subDiagrams flag is not set', async function() {
+
+      await runExport([
+        `${ subdiagramInput }${pathDelimiter}subdiagrams-no-subs.pdf`
+      ]);
+
+      expectExists('subdiagrams-no-subs.pdf', true);
+
+      const pdfBuffer = readFileSync(joinPath(__dirname, 'subdiagrams-no-subs.pdf'));
+      const pdfDoc = await PDFDocument.load(pdfBuffer);
+
+      expect(pdfDoc.getPageCount()).to.equal(1);
     });
 
   });

--- a/test/index-spec.cjs
+++ b/test/index-spec.cjs
@@ -1,7 +1,8 @@
 const { expect } = require('chai');
 
 const {
-  accessSync
+  accessSync,
+  readFileSync
 } = require('node:fs');
 
 const {
@@ -20,11 +21,17 @@ const outputPNG = pathJoin(__dirname, 'diagram.png');
 const outputPDF = pathJoin(__dirname, 'diagram.pdf');
 const outputSVG = pathJoin(__dirname, 'diagram.svg');
 
+const subdiagramInput = pathJoin(__dirname, 'subdiagrams.bpmn');
+const subdiagramPNG = pathJoin(__dirname, 'subdiagrams.png');
+const subdiagramPDF = pathJoin(__dirname, 'subdiagrams.pdf');
+
+const { PDFDocument } = require('pdf-lib');
+
 
 describe('index', function() {
 
   // tests may take some time
-  this.timeout(10000);
+  this.timeout(20000);
 
 
   process.env.NO_CLEANUP || afterEach(async function() {
@@ -70,6 +77,55 @@ describe('index', function() {
       // then
       expectExists(outputPNG, true);
       expectExists(outputPDF, false);
+    });
+
+  });
+
+
+
+  describe('with sub diagrams', function() {
+
+    it('should export collapsed sub processes as separate images', async function() {
+
+      // when
+      await convertAll([
+        {
+          input: subdiagramInput,
+          outputs: [ subdiagramPNG ]
+        }
+      ], {
+        subDiagrams: true
+      });
+
+      // then
+      expectExists(subdiagramPNG, true);
+      expectExists(pathJoin(__dirname, 'subdiagrams-sub-1.png'), true);
+      expectExists(pathJoin(__dirname, 'subdiagrams-sub-2.png'), true);
+      expectExists(pathJoin(__dirname, 'subdiagrams-sub-2-1.png'), true);
+      expectExists(pathJoin(__dirname, 'subdiagrams-sub-3.png'), true);
+    });
+
+
+    it('should merge all diagrams into a single PDF', async function() {
+
+      // when
+      await convertAll([
+        {
+          input: subdiagramInput,
+          outputs: [ subdiagramPDF ]
+        }
+      ], {
+        subDiagrams: true
+      });
+
+      // then
+      expectExists(subdiagramPDF, true);
+
+      const pdfBuffer = readFileSync(subdiagramPDF);
+
+      const pdfDoc = await PDFDocument.load(pdfBuffer);
+
+      expect(pdfDoc.getPageCount()).to.equal(5);
     });
 
   });

--- a/test/index-spec.cjs
+++ b/test/index-spec.cjs
@@ -99,10 +99,10 @@ describe('index', function() {
 
       // then
       expectExists(subdiagramPNG, true);
-      expectExists(pathJoin(__dirname, 'subdiagrams-sub-1.png'), true);
-      expectExists(pathJoin(__dirname, 'subdiagrams-sub-2.png'), true);
-      expectExists(pathJoin(__dirname, 'subdiagrams-sub-2-1.png'), true);
-      expectExists(pathJoin(__dirname, 'subdiagrams-sub-3.png'), true);
+      expectExists(pathJoin(__dirname, 'subdiagrams-1utzm6g.png'), true);
+      expectExists(pathJoin(__dirname, 'subdiagrams-1k00b0l.png'), true);
+      expectExists(pathJoin(__dirname, 'subdiagrams-173ua2j.png'), true);
+      expectExists(pathJoin(__dirname, 'subdiagrams-1elvc1o.png'), true);
     });
 
 
@@ -125,7 +125,8 @@ describe('index', function() {
 
       const pdfDoc = await PDFDocument.load(pdfBuffer);
 
-      expect(pdfDoc.getPageCount()).to.equal(5);
+      // Expect at least main + some subdiagrams
+      expect(pdfDoc.getPageCount()).to.be.greaterThanOrEqual(1);
     });
 
   });

--- a/test/index-spec.cjs
+++ b/test/index-spec.cjs
@@ -31,7 +31,7 @@ const { PDFDocument } = require('pdf-lib');
 describe('index', function() {
 
   // tests may take some time
-  this.timeout(20000);
+  this.timeout(30000);
 
 
   process.env.NO_CLEANUP || afterEach(async function() {
@@ -126,7 +126,51 @@ describe('index', function() {
       const pdfDoc = await PDFDocument.load(pdfBuffer);
 
       // Expect at least main + some subdiagrams
-      expect(pdfDoc.getPageCount()).to.be.greaterThanOrEqual(1);
+      expect(pdfDoc.getPageCount()).to.equal(5);
+    });
+
+  });
+
+
+  describe('ignoring sub diagrams', function() {
+
+    it('should export only main diagram as PNG when subDiagrams option is not set', async function() {
+
+      // when
+      await convertAll([
+        {
+          input: subdiagramInput,
+          outputs: [ pathJoin(__dirname, 'subdiagrams-no-subs.png') ]
+        }
+      ]);
+
+      // then
+      expectExists(pathJoin(__dirname, 'subdiagrams-no-subs.png'), true);
+      expectExists(pathJoin(__dirname, 'subdiagrams-no-subs-1utzm6g.png'), false);
+      expectExists(pathJoin(__dirname, 'subdiagrams-no-subs-1k00b0l.png'), false);
+      expectExists(pathJoin(__dirname, 'subdiagrams-no-subs-173ua2j.png'), false);
+      expectExists(pathJoin(__dirname, 'subdiagrams-no-subs-1elvc1o.png'), false);
+    });
+
+
+    it('should export only main diagram as PDF when subDiagrams option is not set', async function() {
+
+      // when
+      await convertAll([
+        {
+          input: subdiagramInput,
+          outputs: [ pathJoin(__dirname, 'subdiagrams-no-subs-main.pdf') ]
+        }
+      ]);
+
+      // then
+      expectExists(pathJoin(__dirname, 'subdiagrams-no-subs-main.pdf'), true);
+
+      const pdfBuffer = readFileSync(pathJoin(__dirname, 'subdiagrams-no-subs-main.pdf'));
+
+      const pdfDoc = await PDFDocument.load(pdfBuffer);
+
+      expect(pdfDoc.getPageCount()).to.equal(1);
     });
 
   });

--- a/test/subdiagrams.bpmn
+++ b/test/subdiagrams.bpmn
@@ -1,0 +1,308 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0ih168b" targetNamespace="http://bpmn.io/schema/bpmn" exporter="bpmn-js (https://demo.bpmn.io)" exporterVersion="18.10.1">
+  <bpmn:collaboration id="Collaboration_1dn46du">
+    <bpmn:participant id="Participant_1trvwj1" processRef="Process_0w319rv" />
+  </bpmn:collaboration>
+  <bpmn:process id="Process_0w319rv" isExecutable="false">
+    <bpmn:startEvent id="StartEvent_1fst7cn">
+      <bpmn:outgoing>Flow_076p4pj</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="Activity_0o4ti5d" name="Step 1">
+      <bpmn:incoming>Flow_0n0hto0</bpmn:incoming>
+      <bpmn:outgoing>Flow_04md5nd</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:task id="Activity_0n1v04g" name="Step2">
+      <bpmn:incoming>Flow_0z42kf2</bpmn:incoming>
+      <bpmn:outgoing>Flow_03zncxy</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:subProcess id="Activity_1k00b0l" name="Subdiagram 1">
+      <bpmn:incoming>Flow_076p4pj</bpmn:incoming>
+      <bpmn:outgoing>Flow_0n0hto0</bpmn:outgoing>
+      <bpmn:startEvent id="Event_0i63euw">
+        <bpmn:outgoing>Flow_11j9hj1</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:task id="Activity_1ev88ef" name="Step 1.1">
+        <bpmn:incoming>Flow_11j9hj1</bpmn:incoming>
+        <bpmn:outgoing>Flow_1wffzj2</bpmn:outgoing>
+      </bpmn:task>
+      <bpmn:sequenceFlow id="Flow_11j9hj1" sourceRef="Event_0i63euw" targetRef="Activity_1ev88ef" />
+      <bpmn:endEvent id="Event_1m0kp8o">
+        <bpmn:incoming>Flow_1wffzj2</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_1wffzj2" sourceRef="Activity_1ev88ef" targetRef="Event_1m0kp8o" />
+    </bpmn:subProcess>
+    <bpmn:subProcess id="Activity_173ua2j" name="Subdiagram 2">
+      <bpmn:incoming>Flow_04md5nd</bpmn:incoming>
+      <bpmn:outgoing>Flow_0z42kf2</bpmn:outgoing>
+      <bpmn:startEvent id="Event_0qvw4gr">
+        <bpmn:outgoing>Flow_0mdczz6</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:task id="Activity_1dbjl0k" name="Step 2.1">
+        <bpmn:incoming>Flow_0mdczz6</bpmn:incoming>
+        <bpmn:outgoing>Flow_1hili2w</bpmn:outgoing>
+      </bpmn:task>
+      <bpmn:sequenceFlow id="Flow_0mdczz6" sourceRef="Event_0qvw4gr" targetRef="Activity_1dbjl0k" />
+      <bpmn:sequenceFlow id="Flow_1hili2w" sourceRef="Activity_1dbjl0k" targetRef="Activity_1utzm6g" />
+      <bpmn:endEvent id="Event_1dffnc3">
+        <bpmn:incoming>Flow_0hhaxe8</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_0hhaxe8" sourceRef="Activity_1utzm6g" targetRef="Event_1dffnc3" />
+      <bpmn:subProcess id="Activity_1utzm6g" name="Sub-subdiagram 2.1">
+        <bpmn:incoming>Flow_1hili2w</bpmn:incoming>
+        <bpmn:outgoing>Flow_0hhaxe8</bpmn:outgoing>
+        <bpmn:startEvent id="Event_1uolo0l">
+          <bpmn:outgoing>Flow_0doh29w</bpmn:outgoing>
+        </bpmn:startEvent>
+        <bpmn:task id="Activity_09cvrzk" name="Step 2.1.1">
+          <bpmn:incoming>Flow_0doh29w</bpmn:incoming>
+          <bpmn:outgoing>Flow_0o3u8rm</bpmn:outgoing>
+        </bpmn:task>
+        <bpmn:sequenceFlow id="Flow_0doh29w" sourceRef="Event_1uolo0l" targetRef="Activity_09cvrzk" />
+        <bpmn:task id="Activity_1khr6ij" name="Step 2.1.2">
+          <bpmn:incoming>Flow_0o3u8rm</bpmn:incoming>
+          <bpmn:outgoing>Flow_1y5rjyo</bpmn:outgoing>
+        </bpmn:task>
+        <bpmn:sequenceFlow id="Flow_0o3u8rm" sourceRef="Activity_09cvrzk" targetRef="Activity_1khr6ij" />
+        <bpmn:task id="Activity_1do1ljb" name="Step 2.1.3">
+          <bpmn:incoming>Flow_1y5rjyo</bpmn:incoming>
+          <bpmn:outgoing>Flow_00evuv3</bpmn:outgoing>
+        </bpmn:task>
+        <bpmn:sequenceFlow id="Flow_1y5rjyo" sourceRef="Activity_1khr6ij" targetRef="Activity_1do1ljb" />
+        <bpmn:endEvent id="Event_1cepm7x">
+          <bpmn:incoming>Flow_00evuv3</bpmn:incoming>
+        </bpmn:endEvent>
+        <bpmn:sequenceFlow id="Flow_00evuv3" sourceRef="Activity_1do1ljb" targetRef="Event_1cepm7x" />
+      </bpmn:subProcess>
+    </bpmn:subProcess>
+    <bpmn:sequenceFlow id="Flow_076p4pj" sourceRef="StartEvent_1fst7cn" targetRef="Activity_1k00b0l" />
+    <bpmn:sequenceFlow id="Flow_0n0hto0" sourceRef="Activity_1k00b0l" targetRef="Activity_0o4ti5d" />
+    <bpmn:sequenceFlow id="Flow_04md5nd" sourceRef="Activity_0o4ti5d" targetRef="Activity_173ua2j" />
+    <bpmn:sequenceFlow id="Flow_0z42kf2" sourceRef="Activity_173ua2j" targetRef="Activity_0n1v04g" />
+    <bpmn:sequenceFlow id="Flow_03zncxy" sourceRef="Activity_0n1v04g" targetRef="Activity_1elvc1o" />
+    <bpmn:endEvent id="Event_1ct41xi">
+      <bpmn:incoming>Flow_0opv4om</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0opv4om" sourceRef="Activity_1elvc1o" targetRef="Event_1ct41xi" />
+    <bpmn:subProcess id="Activity_1elvc1o" name="Subdiagram 3">
+      <bpmn:incoming>Flow_03zncxy</bpmn:incoming>
+      <bpmn:outgoing>Flow_0opv4om</bpmn:outgoing>
+      <bpmn:startEvent id="Event_1lrw1ow">
+        <bpmn:outgoing>Flow_04dlzli</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:task id="Activity_0w2vk38" name="Step 3.1">
+        <bpmn:incoming>Flow_04dlzli</bpmn:incoming>
+        <bpmn:outgoing>Flow_1urupcy</bpmn:outgoing>
+      </bpmn:task>
+      <bpmn:sequenceFlow id="Flow_04dlzli" sourceRef="Event_1lrw1ow" targetRef="Activity_0w2vk38" />
+      <bpmn:task id="Activity_1gme0o0" name="Step 3.2">
+        <bpmn:incoming>Flow_1urupcy</bpmn:incoming>
+        <bpmn:outgoing>Flow_1hgj9ow</bpmn:outgoing>
+      </bpmn:task>
+      <bpmn:sequenceFlow id="Flow_1urupcy" sourceRef="Activity_0w2vk38" targetRef="Activity_1gme0o0" />
+      <bpmn:task id="Activity_1uoob4j" name="Step 3.3">
+        <bpmn:incoming>Flow_1hgj9ow</bpmn:incoming>
+        <bpmn:outgoing>Flow_0p7ykzg</bpmn:outgoing>
+      </bpmn:task>
+      <bpmn:sequenceFlow id="Flow_1hgj9ow" sourceRef="Activity_1gme0o0" targetRef="Activity_1uoob4j" />
+      <bpmn:task id="Activity_001crhb" name="Step 3.4">
+        <bpmn:incoming>Flow_0p7ykzg</bpmn:incoming>
+        <bpmn:outgoing>Flow_0rj78ll</bpmn:outgoing>
+      </bpmn:task>
+      <bpmn:sequenceFlow id="Flow_0p7ykzg" sourceRef="Activity_1uoob4j" targetRef="Activity_001crhb" />
+      <bpmn:endEvent id="Event_1i7dm35">
+        <bpmn:incoming>Flow_0rj78ll</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_0rj78ll" sourceRef="Activity_001crhb" targetRef="Event_1i7dm35" />
+    </bpmn:subProcess>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_1dn46du">
+      <bpmndi:BPMNShape id="Participant_1trvwj1_di" bpmnElement="Participant_1trvwj1" isHorizontal="true">
+        <dc:Bounds x="160" y="40" width="1108" height="250" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1fst7cn">
+        <dc:Bounds x="242" y="112" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0o4ti5d_di" bpmnElement="Activity_0o4ti5d">
+        <dc:Bounds x="490" y="90" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0n1v04g_di" bpmnElement="Activity_0n1v04g">
+        <dc:Bounds x="810" y="90" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1ct41xi_di" bpmnElement="Event_1ct41xi">
+        <dc:Bounds x="1132" y="112" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1oc6y7j_di" bpmnElement="Activity_1k00b0l">
+        <dc:Bounds x="330" y="90" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0859r1i_di" bpmnElement="Activity_173ua2j">
+        <dc:Bounds x="650" y="90" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1r3nqru_di" bpmnElement="Activity_1elvc1o">
+        <dc:Bounds x="970" y="90" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_076p4pj_di" bpmnElement="Flow_076p4pj">
+        <di:waypoint x="278" y="130" />
+        <di:waypoint x="330" y="130" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0n0hto0_di" bpmnElement="Flow_0n0hto0">
+        <di:waypoint x="430" y="130" />
+        <di:waypoint x="490" y="130" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_04md5nd_di" bpmnElement="Flow_04md5nd">
+        <di:waypoint x="590" y="130" />
+        <di:waypoint x="650" y="130" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0z42kf2_di" bpmnElement="Flow_0z42kf2">
+        <di:waypoint x="750" y="130" />
+        <di:waypoint x="810" y="130" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_03zncxy_di" bpmnElement="Flow_03zncxy">
+        <di:waypoint x="910" y="130" />
+        <di:waypoint x="970" y="130" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0opv4om_di" bpmnElement="Flow_0opv4om">
+        <di:waypoint x="1070" y="130" />
+        <di:waypoint x="1132" y="130" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_12lvsdx">
+    <bpmndi:BPMNPlane id="BPMNPlane_1bcfedg" bpmnElement="Activity_1k00b0l">
+      <bpmndi:BPMNShape id="Event_0i63euw_di" bpmnElement="Event_0i63euw">
+        <dc:Bounds x="152" y="152" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1ev88ef_di" bpmnElement="Activity_1ev88ef">
+        <dc:Bounds x="240" y="130" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1m0kp8o_di" bpmnElement="Event_1m0kp8o">
+        <dc:Bounds x="392" y="152" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_11j9hj1_di" bpmnElement="Flow_11j9hj1">
+        <di:waypoint x="188" y="170" />
+        <di:waypoint x="240" y="170" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1wffzj2_di" bpmnElement="Flow_1wffzj2">
+        <di:waypoint x="340" y="170" />
+        <di:waypoint x="392" y="170" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_009oyci">
+    <bpmndi:BPMNPlane id="BPMNPlane_09adwsg" bpmnElement="Activity_173ua2j">
+      <bpmndi:BPMNShape id="Event_0qvw4gr_di" bpmnElement="Event_0qvw4gr">
+        <dc:Bounds x="142" y="202" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1dbjl0k_di" bpmnElement="Activity_1dbjl0k">
+        <dc:Bounds x="230" y="180" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1dffnc3_di" bpmnElement="Event_1dffnc3">
+        <dc:Bounds x="552" y="202" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0972qld_di" bpmnElement="Activity_1utzm6g">
+        <dc:Bounds x="390" y="180" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0mdczz6_di" bpmnElement="Flow_0mdczz6">
+        <di:waypoint x="178" y="220" />
+        <di:waypoint x="230" y="220" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1hili2w_di" bpmnElement="Flow_1hili2w">
+        <di:waypoint x="330" y="220" />
+        <di:waypoint x="390" y="220" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0hhaxe8_di" bpmnElement="Flow_0hhaxe8">
+        <di:waypoint x="490" y="220" />
+        <di:waypoint x="552" y="220" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1f5r62d">
+    <bpmndi:BPMNPlane id="BPMNPlane_1qcqmax" bpmnElement="Activity_1utzm6g">
+      <bpmndi:BPMNShape id="Event_1uolo0l_di" bpmnElement="Event_1uolo0l">
+        <dc:Bounds x="142" y="222" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_09cvrzk_di" bpmnElement="Activity_09cvrzk">
+        <dc:Bounds x="230" y="200" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1khr6ij_di" bpmnElement="Activity_1khr6ij">
+        <dc:Bounds x="390" y="200" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1do1ljb_di" bpmnElement="Activity_1do1ljb">
+        <dc:Bounds x="550" y="200" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1cepm7x_di" bpmnElement="Event_1cepm7x">
+        <dc:Bounds x="712" y="222" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0doh29w_di" bpmnElement="Flow_0doh29w">
+        <di:waypoint x="178" y="240" />
+        <di:waypoint x="230" y="240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0o3u8rm_di" bpmnElement="Flow_0o3u8rm">
+        <di:waypoint x="330" y="240" />
+        <di:waypoint x="390" y="240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1y5rjyo_di" bpmnElement="Flow_1y5rjyo">
+        <di:waypoint x="490" y="240" />
+        <di:waypoint x="550" y="240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_00evuv3_di" bpmnElement="Flow_00evuv3">
+        <di:waypoint x="650" y="240" />
+        <di:waypoint x="712" y="240" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_0k96tlo">
+    <bpmndi:BPMNPlane id="BPMNPlane_0swj84u" bpmnElement="Activity_1elvc1o">
+      <bpmndi:BPMNShape id="Event_1lrw1ow_di" bpmnElement="Event_1lrw1ow">
+        <dc:Bounds x="162" y="172" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0w2vk38_di" bpmnElement="Activity_0w2vk38">
+        <dc:Bounds x="250" y="150" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1gme0o0_di" bpmnElement="Activity_1gme0o0">
+        <dc:Bounds x="410" y="150" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1uoob4j_di" bpmnElement="Activity_1uoob4j">
+        <dc:Bounds x="570" y="150" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_001crhb_di" bpmnElement="Activity_001crhb">
+        <dc:Bounds x="730" y="150" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1i7dm35_di" bpmnElement="Event_1i7dm35">
+        <dc:Bounds x="892" y="172" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_04dlzli_di" bpmnElement="Flow_04dlzli">
+        <di:waypoint x="198" y="190" />
+        <di:waypoint x="250" y="190" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1urupcy_di" bpmnElement="Flow_1urupcy">
+        <di:waypoint x="350" y="190" />
+        <di:waypoint x="410" y="190" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1hgj9ow_di" bpmnElement="Flow_1hgj9ow">
+        <di:waypoint x="510" y="190" />
+        <di:waypoint x="570" y="190" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0p7ykzg_di" bpmnElement="Flow_0p7ykzg">
+        <di:waypoint x="670" y="190" />
+        <di:waypoint x="730" y="190" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0rj78ll_di" bpmnElement="Flow_0rj78ll">
+        <di:waypoint x="830" y="190" />
+        <di:waypoint x="892" y="190" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
### Proposed Changes

This adds support for exporting collapsed subdiagrams. For image export, this will create one image per subdiagram suffixed by the diagram ID. For PDF export, this will generate a multi-paged PDF with the first page showing the main diagram followed by one page for each subdiagram in alphabetical order (by title).

Closes #44.

```sh
> $ ./cli.js --subdiagrams test/subdiagrams.bpmn:subdiagrams.png
writing subdiagrams.png
writing subdiagrams-1utzm6g.png
writing subdiagrams-1k00b0l.png
writing subdiagrams-173ua2j.png
writing subdiagrams-1elvc1o.png

> $ ./cli.js --subdiagrams test/subdiagrams.bpmn:subdiagrams.pdf
writing subdiagrams.pdf
```

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
  * *Note: I wasn't able to run the linter but I assume this will be done by the pipeline. Let me know if you require any changes*
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
